### PR TITLE
[run_dev.sh] Ensure that a fresh Git clone contains folder data/dict/

### DIFF
--- a/download_dicts.sh
+++ b/download_dicts.sh
@@ -40,9 +40,6 @@ for language_from in "${languages[@]}"; do
 done
 
 
-mkdir -p data/dict
-
-
 for name in wikdict "${languages[@]}" "${language_pairs[@]}"; do
     basename="${name}.sqlite3"
     filename="data/dict/${basename}"


### PR DESCRIPTION
Previously, without the folder present you would run into:
`sqlite3.OperationalError: unable to open database file`

In more detail:
```console
# ./run_dev.sh 
Collecting git+git://github.com/karlb/pysqlite3
  Cloning git://github.com/karlb/pysqlite3 to /tmp/pip-req-build-eiiiqvgk
  Running command git clone -q git://github.com/karlb/pysqlite3 /tmp/pip-req-build-eiiiqvgk
Using legacy 'setup.py install' for pysqlite3, since package 'wheel' is not installed.
Installing collected packages: pysqlite3
    Running setup.py install for pysqlite3 ... done
Successfully installed pysqlite3-0.2.0
WARNING: You are using pip version 21.1.1; however, version 21.3.1 is available.
You should consider upgrading via the '/tmp/tmp.OwskbHnXnt/wikdict-web/venv/bin/python3 -m pip install --upgrade pip' command.
WARNING: You are using pip version 21.1.1; however, version 21.3.1 is available.
You should consider upgrading via the '/tmp/tmp.OwskbHnXnt/wikdict-web/venv/bin/python3 -m pip install --upgrade pip' command.
 * Serving Flask app 'wikdict_web' (lazy loading)
 * Environment: production
   WARNING: This is a development server. Do not use it in a production deployment.
   Use a production WSGI server instead.
 * Debug mode: on
 * Running on http://127.0.0.1:5000/ (Press CTRL+C to quit)
 * Restarting with stat
 * Debugger is active!
 * Debugger PIN: 137-210-354
data/dict/wikdict.sqlite3
127.0.0.1 - - [09/Nov/2021 17:14:04] "GET / HTTP/1.1" 500 -
Traceback (most recent call last):
  File "/tmp/tmp.OwskbHnXnt/wikdict-web/venv/lib/python3.8/site-packages/flask/app.py", line 2091, in __call__
    return self.wsgi_app(environ, start_response)
  File "/tmp/tmp.OwskbHnXnt/wikdict-web/venv/lib/python3.8/site-packages/flask/app.py", line 2076, in wsgi_app
    response = self.handle_exception(e)
  File "/tmp/tmp.OwskbHnXnt/wikdict-web/venv/lib/python3.8/site-packages/flask/app.py", line 2073, in wsgi_app
    response = self.full_dispatch_request()
  File "/tmp/tmp.OwskbHnXnt/wikdict-web/venv/lib/python3.8/site-packages/flask/app.py", line 1518, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/tmp/tmp.OwskbHnXnt/wikdict-web/venv/lib/python3.8/site-packages/flask/app.py", line 1516, in full_dispatch_request
    rv = self.dispatch_request()
  File "/tmp/tmp.OwskbHnXnt/wikdict-web/venv/lib/python3.8/site-packages/flask/app.py", line 1502, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**req.view_args)
  File "/tmp/tmp.OwskbHnXnt/wikdict-web/wikdict_web/__init__.py", line 58, in index
    return lookup.lookup(from_lang, to_lang)
  File "/tmp/tmp.OwskbHnXnt/wikdict-web/wikdict_web/lookup.py", line 108, in lookup
    sum(lp.total_trans for lp in base.get_lang_pairs()) // 100000 / 10
  File "/tmp/tmp.OwskbHnXnt/wikdict-web/wikdict_web/base.py", line 21, in f_with_timing
    result = f(*args, **kwargs)
  File "/tmp/tmp.OwskbHnXnt/wikdict-web/wikdict_web/base.py", line 45, in get_lang_pairs
    return db_query('wikdict', """
  File "/tmp/tmp.OwskbHnXnt/wikdict-web/wikdict_web/base.py", line 95, in db_query
    conn = get_conn(db_name, path, attach_dbs)
  File "/tmp/tmp.OwskbHnXnt/wikdict-web/wikdict_web/base.py", line 86, in get_conn
    conn = sqlite3.connect(path_for_db(db_name, path))
sqlite3.OperationalError: unable to open database file
127.0.0.1 - - [09/Nov/2021 17:14:04] "GET /?__debugger__=yes&cmd=resource&f=style.css HTTP/1.1" 200 -
127.0.0.1 - - [09/Nov/2021 17:14:04] "GET /?__debugger__=yes&cmd=resource&f=debugger.js HTTP/1.1" 200 -
127.0.0.1 - - [09/Nov/2021 17:14:04] "GET /?__debugger__=yes&cmd=resource&f=console.png HTTP/1.1" 200 -
127.0.0.1 - - [09/Nov/2021 17:14:05] "GET /?__debugger__=yes&cmd=resource&f=ubuntu.ttf HTTP/1.1" 200 -
127.0.0.1 - - [09/Nov/2021 17:14:05] "GET /?__debugger__=yes&cmd=resource&f=console.png HTTP/1.1" 200 -
```