### PR TITLE
Run tests using GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# Copyright (c) 2021 Sebastian Pipping <sebastian@pipping.org>
+# Licensed under the MIT license, see file COPYING for the full text
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    commit-message:
+      include: "scope"
+      prefix: "Actions"
+    directory: "/"
+    labels:
+      - "enhancement"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -1,0 +1,32 @@
+# Copyright (c) 2021 Sebastian Pipping <sebastian@pipping.org>
+# Licensed under the MIT license, see file COPYING for the full text
+
+name: Run tests
+
+on:
+- pull_request
+- push
+
+jobs:
+  run-tests:
+    name: Run tests
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2.4.0
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2.2.2
+        with:
+          python-version: '3.9'
+
+      - name: Download necessary databases
+        run: |-
+          set -x
+          for name in de de-en en en-de wikdict; do
+            basename="${name}.sqlite3"
+            wget -q -O "data/dict/${basename}" "https://download.wikdict.com/dictionaries/wdweb/${basename}"
+          done
+
+      - name: Run tests
+        run: |-
+          ./run_dev.sh test


### PR DESCRIPTION
~This sits on top of #4 and #10 (due to semantic dependency) but I can rebase it off of them after the dependencies are merged, if you prefer…~

There is some duplication in here with `download_dicts.sh` from #6 here. We can adjust that script to only pull a subset, if it's important to you to avoid that duplication, now or later.

Also please note, that in this form the CI will download the same five files off your server for every run. That can be turned to GitHub Actions own caching, where it's then downloading from "itself". I consider that an optimisation personally, unless you consider it a showstopper for the first version to merge, already.

Here's what to except from this pull request (over at my fork, before GitHub picks it up over here): https://github.com/hartwork/wikdict-web/actions/runs/1441308872

PS: Here's an example for the PRs that GitHub Dependabot will create for you in the future: https://github.com/hartwork/jawanndenn/pull/221 .

Looking forward to your feedback :beers: 