### PR TITLE
Convert most http:// URIs to https:// (for user privacy and MITM protection)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is the web front end for WikDict dictionaries, which is running at [www.wikdict.com].
 
-[www.wikdict.com]: http://www.wikdict.com
+[www.wikdict.com]: https://www.wikdict.com
 
 # Development Setup
 

--- a/cors.json
+++ b/cors.json
@@ -1,6 +1,6 @@
 [
     {
-      "origin": ["http://www.wikdict.com", "*"],
+      "origin": ["*"],
       "responseHeader": ["Content-Type"],
       "method": ["GET", "HEAD", "DELETE"],
       "maxAgeSeconds": 3600

--- a/static/root/robots.txt
+++ b/static/root/robots.txt
@@ -1,3 +1,3 @@
 User-Agent: *
 Crawl-Delay: 5
-Sitemap: http://www.wikdict.com/static/sitemap/index.xml
+Sitemap: https://www.wikdict.com/static/sitemap/index.xml

--- a/wikdict_web/lookup.py
+++ b/wikdict_web/lookup.py
@@ -161,7 +161,7 @@ def spellfix(from_lang, to_lang, search_term):
 
 @timing
 def get_wiktionary_links(lang, word):
-    url = 'http://%s.wiktionary.org/wiki/%s#%s'
+    url = 'https://%s.wiktionary.org/wiki/%s#%s'
     lang_name = urllib.parse.quote_plus(language_names[lang]).replace('%', '.')
     sql = """
         SELECT written_rep FROM vocable

--- a/wikdict_web/markdown/about.md
+++ b/wikdict_web/markdown/about.md
@@ -20,7 +20,7 @@ WikDict aims to provide free bilingual dictionary data for all use cases. You ar
 #### Which data is available and where does if come from?
 
 <img style="float: right; width: 15%" src="/static/img/markdown/mit-license.svg">
-All data is extracted from [Wiktionary](http://www.wiktionary.org) by the [DBnary](http://kaiko.getalp.org/about-dbnary/) project. So for data to be available, it has to be in one the the Wiktionaries support by DBnary. On top of the extraction work done by DBnary, WikDict
+All data is extracted from [Wiktionary](https://www.wiktionary.org) by the [DBnary](http://kaiko.getalp.org/about-dbnary/) project. So for data to be available, it has to be in one the the Wiktionaries support by DBnary. On top of the extraction work done by DBnary, WikDict
 
 * parses HTML and Wiki formatting from the results to provide proper human-readable output 
 * reduces the differences in data structure between different language Wiktionaries
@@ -42,4 +42,4 @@ If you are willing to write code or want to contribute in a different way, pleas
 [issues]: https://github.com/karlb/wikdict-web/issues
 
 ---
-<small>MIT license logo by [ExcaliburZero](http://excaliburzero.deviantart.com/art/MIT-License-Logo-595847140)</small>
+<small>MIT license logo by [ExcaliburZero](https://excaliburzero.deviantart.com/art/MIT-License-Logo-595847140)</small>

--- a/wikdict_web/markdown/contact.md
+++ b/wikdict_web/markdown/contact.md
@@ -2,6 +2,6 @@
 
 <address>
     <strong>Karl Bartel</strong><br>
-    <a href="http://www.karl.berlin">www.karl.berlin</a><br>
+    <a href="https://www.karl.berlin">www.karl.berlin</a><br>
     <a href="mailto:karl@karl.berlin">karl@karl.berlin</a>
 </address>

--- a/wikdict_web/markdown/download.md
+++ b/wikdict_web/markdown/download.md
@@ -8,7 +8,7 @@ Please request new formats by creating a [github issue](https://github.com/karlb
 
 #### StarDict
 
-The [dictionaries in StarDict format](http://download.wikdict.com/dictionaries/stardict/) can be used with a wide variety of different dictionary applications, e.g.:
+The [dictionaries in StarDict format](https://download.wikdict.com/dictionaries/stardict/) can be used with a wide variety of different dictionary applications, e.g.:
 
 * [GoldenDict](http://goldendict.org/) for Linux, Windows
 * [GoldenDict mobile](http://goldendict.mobi/) for Android (non-free)
@@ -17,7 +17,7 @@ The [dictionaries in StarDict format](http://download.wikdict.com/dictionaries/s
 
 #### Kobo E-Readers
 
-After downloading [dictionaries for Kobo e-readers](http://download.wikdict.com/dictionaries/kobo/), connect your e-reader to your PC and copy the zip file(s) to the `.kobo/dict/` folder on your device. Then disconnect the device and enjoy the new dictionaries!
+After downloading [dictionaries for Kobo e-readers](https://download.wikdict.com/dictionaries/kobo/), connect your e-reader to your PC and copy the zip file(s) to the `.kobo/dict/` folder on your device. Then disconnect the device and enjoy the new dictionaries!
 
 ### For Developers
 
@@ -25,7 +25,7 @@ Apart from the end user oriented dictionaries, the raw information is also avail
 
 #### SQLite Databases
 
-This is the native format used by WikDict. [These databases](http://download.wikdict.com/dictionaries/sqlite) contain all information available on the website and all other formats are created by converting from this format. Use the [sqlite3 command line tool](https://sqlite.org/cli.html) or one of the many other database tools with SQLite support to interact with the data.
+This is the native format used by WikDict. [These databases](https://download.wikdict.com/dictionaries/sqlite) contain all information available on the website and all other formats are created by converting from this format. Use the [sqlite3 command line tool](https://sqlite.org/cli.html) or one of the many other database tools with SQLite support to interact with the data.
 
 The data is split up into separate databases, a pair of databases for each language pair (one per direction, mostly containing translation) and one database per language (containing basic information about words, e.g. part of speech, inflections).
 
@@ -33,4 +33,4 @@ To query across multiple databases, use the [`ATTACH DATABASE` command](https://
 
 #### TEI P5 (XML)
 
-If you like XML or come from the linguistic community, you might prefer [these XML files](http://download.wikdict.com/dictionaries/tei/recommended/) encoded in [TEI P5](http://www.tei-c.org/Guidelines/P5/). Each language pair has two XML files, one for each translation direction.
+If you like XML or come from the linguistic community, you might prefer [these XML files](https://download.wikdict.com/dictionaries/tei/recommended/) encoded in [TEI P5](https://www.tei-c.org/Guidelines/P5/). Each language pair has two XML files, one for each translation direction.

--- a/wikdict_web/templates/base.html
+++ b/wikdict_web/templates/base.html
@@ -48,7 +48,7 @@
 					if (document.referrer && (p.exec(document.referrer)[6] !== document.location.hostname))
 					{
 						var x = new XMLHttpRequest();
-						x.open('POST',"http://www.translunary.com/api/v1.0/refer/karl/www.wikdict.com",true);
+						x.open('POST',"https://www.translunary.com/api/v1.0/refer/karl/www.wikdict.com",true);
 						x.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
 						x.send("ref="+encodeURIComponent(document.referrer));
 					}
@@ -95,7 +95,7 @@
             <div class="collapse navbar-collapse" style="justify-content: flex-end" id="collapsible-links">
                 <ul class="navbar-nav">
                     <li class="nav-item"><a class="nav-link {% if page_name == 'about' %}active{% endif %}" href="/page/about">About</a></li>
-                    <li class="nav-item"><a class="nav-link" href="http://blog.wikdict.com">Blog</a></li>
+                    <li class="nav-item"><a class="nav-link" href="https://blog.wikdict.com">Blog</a></li>
                     <li class="nav-item"><a class="nav-link {% if page_name == 'contact' %}active{% endif %}" href="/page/contact">Contact</a></li>
                     <li class="nav-item"><a class="nav-link {% if page_name == 'download' %}active{% endif %}" href="/page/download">Downloads</a></li>
                 </ul>
@@ -131,9 +131,9 @@
 
 		<footer class="footer bg-light py-3">
 			<div class="container text-muted">
-				WikDict by <a href="http://www.karl.berlin">Karl Bartel</a>.
-				Data from <a href="http://www.wiktionary.org">Wiktionary</a>
-				via <a href="http://kaiko.getalp.org/about-dbnary/">DBnary</a>
+				WikDict by <a href="https://www.karl.berlin">Karl Bartel</a>.
+				Data from <a href="https://www.wiktionary.org">Wiktionary</a>
+				via <a href="https://kaiko.getalp.org/about-dbnary/">DBnary</a>
 				licensed under the <a href="//creativecommons.org/licenses/by-sa/3.0/" rel="license">Creative Commons Attribution-ShareAlike License</a>.
 			</div>
 		</footer>

--- a/wikdict_web/templates/lookup.html
+++ b/wikdict_web/templates/lookup.html
@@ -30,7 +30,7 @@
 
     <script type="application/ld+json">
     {
-      "@context": "http://schema.org",
+      "@context": "https://schema.org",
       "@type": "BreadcrumbList",
       "itemListElement": [{
         "@type": "ListItem",

--- a/wikdict_web/templates/opensearch.xml
+++ b/wikdict_web/templates/opensearch.xml
@@ -11,9 +11,9 @@
 		 template="https://www.wikdict.com/opensearch/typeahead/{{from_lang}}-{{to_lang}}/{searchTerms}?utm_source=opensearch"/>
 	<Attribution>WikDict.com data from Wiktionary via DBnary. Licensed under the CC BY-SA 3.0.</Attribution>
 	<SyndicationRight>open</SyndicationRight>
-	<Image height="16" width="16" type="image/png">http://www.wikdict.com/img/icons/favicon-16x16.png</Image>
-	<Image height="32" width="32" type="image/png">http://www.wikdict.com/img/icons/favicon-32x32.png</Image>
-	<Image height="96" width="96" type="image/png">http://www.wikdict.com/img/icons/favicon-96x96.png</Image>
-	<Image height="194" width="194" type="image/png">http://www.wikdict.com/img/icons/favicon-194x194.png</Image>
-	<Image height="16" width="16" type="image/vnd.microsoft.icon">http://www.wikdict.com/img/icons/favicon.ico</Image>
+	<Image height="16" width="16" type="image/png">https://www.wikdict.com/img/icons/favicon-16x16.png</Image>
+	<Image height="32" width="32" type="image/png">https://www.wikdict.com/img/icons/favicon-32x32.png</Image>
+	<Image height="96" width="96" type="image/png">https://www.wikdict.com/img/icons/favicon-96x96.png</Image>
+	<Image height="194" width="194" type="image/png">https://www.wikdict.com/img/icons/favicon-194x194.png</Image>
+	<Image height="16" width="16" type="image/vnd.microsoft.icon">https://www.wikdict.com/img/icons/favicon.ico</Image>
 </OpenSearchDescription>


### PR DESCRIPTION
Exceptions:
- Links to websites that do not support TLS
  - localhost
  - http://kaiko.getalp.org/about-dbnary/
  - http://goldendict.org/
  - http://goldendict.mobi/
- XML namespace URIs
- Language identifiers in `languages.json`