### PR TITLE
README.md: Fix localhost listening port

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,4 @@ Now you can run the development server
 
     ./run_dev.sh
 
-and connect to http://localhost:4000/.
+and connect to http://localhost:5000/.


### PR DESCRIPTION
It's always port **5**000 over here. @karlb with latest flask, is it still **4**000 for you?

```console
# ./run_dev.sh 
WARNING: You are using pip version 21.1.1; however, version 21.3.1 is available.
You should consider upgrading via the '[..]/wikdict-web/venv/bin/python3 -m pip install --upgrade pip' command.
 * Serving Flask app 'wikdict_web' (lazy loading)
 * Environment: production
   WARNING: This is a development server. Do not use it in a production deployment.
   Use a production WSGI server instead.
 * Debug mode: on
 * Running on http://127.0.0.1:5000/ (Press CTRL+C to quit)
 * Restarting with stat
 * Debugger is active!
 * Debugger PIN: 929-651-497
```
